### PR TITLE
Avoid using ES2015 features

### DIFF
--- a/lib/saws.js
+++ b/lib/saws.js
@@ -38,7 +38,7 @@ module.exports = function(AWS) {
         if(!created) {
           self.ddb.createTable(_.merge(_.cloneDeep(opts), {TableName: tableName}), function(err, data) {
             DEBUG("ddb.createTable", err, data);
-            if(err && err.message.includes('Table already exists')) {
+            if(err && ~err.message.indexOf('Table already exists')) {
               created = true;
               status = 'ACTIVE';
               cb();

--- a/lib/saws.js
+++ b/lib/saws.js
@@ -1,7 +1,5 @@
 var _ = require('lodash');
 
-var AWS;
-
 function DEBUG() {
   if(process.env.SAWS_DEBUG)
     console.log.apply(console, arguments);

--- a/lib/saws.js
+++ b/lib/saws.js
@@ -4,7 +4,7 @@ var AWS;
 
 function DEBUG() {
   if(process.env.SAWS_DEBUG)
-    console.log.apply(console, arguments)
+    console.log.apply(console, arguments);
 }
 
 module.exports = function(AWS) {
@@ -46,7 +46,7 @@ module.exports = function(AWS) {
             else {
               waitUntilTableActive(cb);
             }
-          }); 
+          });
         }
         else {
           cb();
@@ -81,7 +81,7 @@ module.exports = function(AWS) {
             });
           });
         }
-      }
+      };
     },
 
     sns: new AWS.SNS(),
@@ -116,9 +116,8 @@ module.exports = function(AWS) {
               });
             }
           });
-          
         }
-      }
+      };
     },
 
     sqs: new AWS.SQS(),
@@ -131,9 +130,9 @@ module.exports = function(AWS) {
             MessageBody: JSON.stringify(msg)
           }, cb);
         }
-      }
+      };
     }
-  }
+  };
 
   return self;
-}
+};

--- a/lib/saws.js
+++ b/lib/saws.js
@@ -9,7 +9,7 @@ function DEBUG() {
 
 module.exports = function(AWS) {
   var self = {
-    stage: "development",
+    stage: 'development',
 
     ddb: new AWS.DynamoDB(),
     doc: new AWS.DynamoDB.DocumentClient(),
@@ -22,7 +22,7 @@ module.exports = function(AWS) {
 
       function waitUntilTableActive(cb) {
         self.ddb.describeTable({TableName: tableName}, function(err, data) {
-          DEBUG("ddb.describeTable", err, data);
+          DEBUG('ddb.describeTable', err, data);
           status = _.get(data, 'Table.TableStatus');
           if(status === 'ACTIVE') {
             created = true;
@@ -37,7 +37,7 @@ module.exports = function(AWS) {
       function initializeTable(cb) {
         if(!created) {
           self.ddb.createTable(_.merge(_.cloneDeep(opts), {TableName: tableName}), function(err, data) {
-            DEBUG("ddb.createTable", err, data);
+            DEBUG('ddb.createTable', err, data);
             if(err && ~err.message.indexOf('Table already exists')) {
               created = true;
               status = 'ACTIVE';
@@ -57,10 +57,10 @@ module.exports = function(AWS) {
         lookup: function(params, cb) {
           initializeTable(function() {
             self.doc.get({
-              "TableName": tableName,
-              "Key": params
+              'TableName': tableName,
+              'Key': params
             }, function(err, data) {
-              DEBUG("ddb.doc.get", err, data);
+              DEBUG('ddb.doc.get', err, data);
               if(cb) {
                 cb(err, data);
               }
@@ -71,10 +71,10 @@ module.exports = function(AWS) {
         save: function(params, cb) {
           initializeTable(function() {
             self.doc.put({
-              "TableName": tableName,
-              "Item": params
+              'TableName': tableName,
+              'Item': params
             }, function(err, data) {
-              DEBUG("ddb.doc.put", err, data);
+              DEBUG('ddb.doc.put', err, data);
               if(cb) {
                 cb(err, data.Item);
               }
@@ -94,7 +94,7 @@ module.exports = function(AWS) {
         }
         else {
           self.sns.createTopic({Name: name + '-' + self.stage}, function(err, data) {
-            DEBUG("sns.createTopic", err, data);
+            DEBUG('sns.createTopic', err, data);
             topicArn = data.TopicArn;
             if(cb) {
               cb(err, data.TopicArn);
@@ -111,7 +111,7 @@ module.exports = function(AWS) {
                 TopicArn: topicArn,
                 Message: JSON.stringify(msg)
               }, function(err, data) {
-                DEBUG("sns.publish", err, data);
+                DEBUG('sns.publish', err, data);
                 cb(err, data);
               });
             }


### PR DESCRIPTION
This will remove the use of `String.prototype.includes()` in favor of `String.prototype.indexOf()` to support older versions of node. See #2.

I took the liberty to fix some style "issues". Let me know if this is not wanted.