### PR TITLE
Add support for DynamoDB.DocumentClient.scan()

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,19 @@ customers.lookup({"IdentityId": "id0000001"}, function(err, data) {
 });
 ```
 
-The `lookup` operation is asynchronous. It takes a key parameter and a callback to be invoked when the operation completes. The `params` object must contain top-level key(s) matching your `KeySchema` or the operation will fail. 
+The `lookup` operation is asynchronous. It takes a key parameter and a callback to be invoked when the operation completes. The `params` object must contain top-level key(s) matching your `KeySchema` or the operation will fail.
 
+#### scan(params, cb)
+
+A thin wrapper around `DynamoDB.DocuemntClient.scan`, accepting the same parameters. [link](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
+The `TableName` should not be passed.
+Returns one or more items and item attributes by accessing every item in a table or a secondary index.
+
+```javascript
+customers.lookup({"IdentityId": "id0000001"}, function(err, data) {
+  console.log(data) // => { "IdentityId": "id0000001", "StripeCustomerId": "cus_00000001" },
+});
+```
 
 ### SNS (Simple Notification Service)
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ The `lookup` operation is asynchronous. It takes a key parameter and a callback 
 
 #### scan(params, cb)
 
-A thin wrapper around `DynamoDB.DocuemntClient.scan`, accepting the same parameters. [link](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
+A thin wrapper around `DynamoDB.DocuemntClient.scan`, accepting the [same parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property).
+
 The `TableName` should not be passed.
+
 Returns one or more items and item attributes by accessing every item in a table or a secondary index.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The `TableName` should not be passed.
 Returns one or more items and item attributes by accessing every item in a table or a secondary index.
 
 ```javascript
-customers.lookup({"IdentityId": "id0000001"}, function(err, data) {
-  console.log(data) // => { "IdentityId": "id0000001", "StripeCustomerId": "cus_00000001" },
+customers.scan({"Verified": false}, function(err, data) {
+  console.log(data) // => [{ "IdentityId": "id0000001", "Verified": false}, { "IdentityId": "id0000004", "Verified": false}]
 });
 ```
 

--- a/lib/saws.js
+++ b/lib/saws.js
@@ -16,7 +16,7 @@ module.exports = function(AWS) {
       var created;
       var status;
 
-      var tableName = opts['TableName'] + '-' + self.stage;
+      var tableName = opts.TableName + '-' + self.stage;
 
       function waitUntilTableActive(cb) {
         self.ddb.describeTable({TableName: tableName}, function(err, data) {
@@ -78,6 +78,17 @@ module.exports = function(AWS) {
               }
             });
           });
+        },
+
+        scan: function(params, cb) {
+          initializeTable(function() {
+            self.doc.scan(_.merge(_.cloneDeep(params), {TableName: tableName}), function(err, data) {
+              DEBUG('ddb.doc.scan', err, data);
+              if(cb) {
+                cb(err, data.Items);
+              }
+            });
+          });
         }
       };
     },
@@ -125,7 +136,7 @@ module.exports = function(AWS) {
             cb(record.Sns, JSON.parse(record.Sns.Message));
           });
         }
-      }
+      };
     },
 
     sqs: new AWS.SQS(),

--- a/tests/dynamo.js
+++ b/tests/dynamo.js
@@ -1,3 +1,4 @@
+// jshint mocha: true
 var _ = require('lodash');
 var chai = require('chai');
 var sinon = require("sinon");
@@ -23,30 +24,38 @@ var tableDefinition = {
 };
 
 describe('DynamoDB functions', function() {
-  var createTableStub;
-  var describeTableStub;
-  var putStub;
-  var getStub;
+  // Give each stub a name with arguments to be passed to sinon.stub
+  var STUB_DEFINITIONS = {
+      createTable: [Saws.ddb, 'createTable'],
+      describeTable: [Saws.ddb, 'describeTable'],
+      put: [Saws.doc, 'put'],
+      get: [Saws.doc, 'get'],
+      scan: [Saws.doc, 'scan']
+  };
+
+  // Each STUB_DEFINITION will have a corresponfing stub created in `stubs`
+  var stubs = {};
 
   beforeEach(function() {
-    createTableStub = sinon.stub(Saws.ddb, 'createTable');
-    describeTableStub = sinon.stub(Saws.ddb, 'describeTable');
-    putStub = sinon.stub(Saws.doc, 'put');
-    getStub = sinon.stub(Saws.doc, 'get');
+    var stubNames = Object.getOwnPropertyNames(STUB_DEFINITIONS);
+
+    for(var i = 0; i < stubNames.length; i++) {
+        stubs[stubNames[i]] = sinon.stub.apply(sinon, STUB_DEFINITIONS[stubNames[i]]);
+    }
   });
 
   afterEach(function() {
-    _.each([createTableStub, describeTableStub, putStub, getStub], function(spy) {
-      spy.restore();
+    _.each(Object.getOwnPropertyNames(stubs), function(stubName) {
+      stubs[stubName].restore();
     });
   });
 
   it('new Saws.Table creates a new table if needed', function(done) {
-    createTableStub.callsArgWith(1, null, {TableStatus: 'CREATING'});
-    describeTableStub.onFirstCall().callsArgWith(1, null, {Table: { TableStatus: 'CREATING'}});
-    describeTableStub.onSecondCall().callsArgWith(1, null, {Table: { TableStatus: 'CREATING'}});
-    describeTableStub.onThirdCall().callsArgWith(1, null, {Table: { TableStatus: 'ACTIVE'}});
-    putStub.callsArgWith(1, null, {});
+    stubs.createTable.callsArgWith(1, null, {TableStatus: 'CREATING'});
+    stubs.describeTable.onFirstCall().callsArgWith(1, null, {Table: { TableStatus: 'CREATING'}});
+    stubs.describeTable.onSecondCall().callsArgWith(1, null, {Table: { TableStatus: 'CREATING'}});
+    stubs.describeTable.onThirdCall().callsArgWith(1, null, {Table: { TableStatus: 'ACTIVE'}});
+    stubs.put.callsArgWith(1, null, {});
 
     var customers = new Saws.Table(tableDefinition);
     customers.save({
@@ -54,26 +63,26 @@ describe('DynamoDB functions', function() {
       "StripeCustomerId": "cus_00000001"
     }, done);
 
-    expect(createTableStub).to.have.been.calledWith(_.merge(_.cloneDeep(tableDefinition), {TableName: "StripeCashier-test"}));
+    expect(stubs.createTable).to.have.been.calledWith(_.merge(_.cloneDeep(tableDefinition), {TableName: "StripeCashier-test"}));
   });
 
   it('operations do not break or call describeTable when table already exists', function(done) {
-    createTableStub.callsArgWith(1, {message: 'Table already exists'});
-    putStub.callsArgWith(1, null, {});
+    stubs.createTable.callsArgWith(1, {message: 'Table already exists'});
+    stubs.put.callsArgWith(1, null, {});
 
     var customers = new Saws.Table(tableDefinition);
     customers.save({
       "IdentityId": "id0000001",
       "StripeCustomerId": "cus_00000001"
     }, done);
-    
-    sinon.assert.notCalled(describeTableStub);
-    sinon.assert.called(putStub);
+
+    sinon.assert.notCalled(stubs.describeTable);
+    sinon.assert.called(stubs.put);
   });
 
   it('save() should persist an object', function(done) {
-    createTableStub.callsArgWith(1, {message: 'Table already exists'});
-    putStub.callsArgWith(1, null, {});
+    stubs.createTable.callsArgWith(1, {message: 'Table already exists'});
+    stubs.put.callsArgWith(1, null, {});
 
     var customers = new Saws.Table(tableDefinition);
     var params = {
@@ -81,24 +90,38 @@ describe('DynamoDB functions', function() {
       "StripeCustomerId": "cus_00000001",
       "Name": "Rylo Ken",
       "Email": "emoryloken@empire.gov"
-    }
+    };
     customers.save(params, done);
 
-    sinon.assert.called(putStub);
-    expect(putStub).to.have.been.calledWith({TableName: "StripeCashier-test", Item: params});
+    sinon.assert.called(stubs.put);
+    expect(stubs.put).to.have.been.calledWith({TableName: "StripeCashier-test", Item: params});
   });
 
   it('lookup() should retrieve a stored object', function(done) {
-    createTableStub.callsArgWith(1, {message: 'Table already exists'});
-    getStub.callsArgWith(1, null, {});
+    stubs.createTable.callsArgWith(1, {message: 'Table already exists'});
+    stubs.get.callsArgWith(1, null, {});
 
     var customers = new Saws.Table(tableDefinition);
     var params = {
       "IdentityId": "id0000001"
-    }
+    };
     customers.lookup(params, done);
-    
-    sinon.assert.called(getStub);
-    expect(getStub).to.have.been.calledWith({Key: params, TableName: "StripeCashier-test"});
+
+    sinon.assert.called(stubs.get);
+    expect(stubs.get).to.have.been.calledWith({Key: params, TableName: "StripeCashier-test"});
+  });
+
+  it('scan() should retrieve multiple stored objects', function(done) {
+    stubs.createTable.callsArgWith(1, {message: 'Table already exists'});
+    stubs.scan.callsArgWith(1, null, {Items: {}});
+
+    var customers = new Saws.Table(tableDefinition);
+    var params = {
+      "IdentityId": "id0000001"
+    };
+    customers.scan(params, done);
+
+    sinon.assert.called(stubs.scan);
+    expect(stubs.scan).to.have.been.calledWith({IdentityId: "id0000001", TableName: "StripeCashier-test"});
   });
 });

--- a/tests/dynamo.js
+++ b/tests/dynamo.js
@@ -111,15 +111,21 @@ describe('DynamoDB functions', function() {
     expect(stubs.get).to.have.been.calledWith({Key: params, TableName: "StripeCashier-test"});
   });
 
-  it('scan() should retrieve multiple stored objects', function(done) {
+  it('should retrieve multiple stored objects with scan()', function(done) {
     stubs.createTable.callsArgWith(1, {message: 'Table already exists'});
-    stubs.scan.callsArgWith(1, null, {Items: {}});
+    stubs.scan.callsArgWith(1, null, {Items: [{name: '1'}, {name: '2'}], NextMarker: 'The next'});
 
     var customers = new Saws.Table(tableDefinition);
     var params = {
       "IdentityId": "id0000001"
     };
-    customers.scan(params, done);
+    customers.scan(params, function(err, items) {
+      expect(err).to.be.null;
+      expect(items).to.be.instanceof(Array);
+      expect(items).to.have.length(2);
+      expect(items[0].name).to.be.equal('1');
+      done();
+    });
 
     sinon.assert.called(stubs.scan);
     expect(stubs.scan).to.have.been.calledWith({IdentityId: "id0000001", TableName: "StripeCashier-test"});


### PR DESCRIPTION
Added a wrapper for `scan()`. Also simplifies stub creation and teardown by defining stubs in `STUB_DEFINITIONS` only.